### PR TITLE
Integration of updated LibQueue and loading batch gaps from meta-db to the queue

### DIFF
--- a/database/sqlite/sqlite_functions.c
+++ b/database/sqlite/sqlite_functions.c
@@ -2158,22 +2158,24 @@ int sql_load_host_gap(RRDHOST *host)
 
     info("%s: Just before the row process of the query:", REPLICATION_MSG);
     // Load here the gaps to the host->gaps_timeline
-    rc = sqlite3_step(res);
-    switch (rc) {
-        case SQLITE_ROW:
-            if (likely(sqlite3_column_bytes(res, 0) == sizeof(uuid_t))) {
-                set_host_gap(host, res);
-                info("%s: Setting host latest gap completed!", REPLICATION_MSG);
-            }
-            break;
-        case SQLITE_DONE:
-            set_host_gap(host, NULL);
-            info("%s: SQLite completed with NO ROWs!", REPLICATION_MSG);
-            break;
-        default:
-            error("%s: SQLite returned unexpected error code!", REPLICATION_MSG);
-            break;
-    }
+    do{
+        rc = sqlite3_step(res);
+        switch (rc) {
+            case SQLITE_ROW:
+                if (likely(sqlite3_column_bytes(res, 0) == sizeof(uuid_t))) {
+                    set_host_gap(host, res);
+                    info("%s: Setting host latest gap completed!", REPLICATION_MSG);
+                }
+                break;
+            case SQLITE_DONE:
+                set_host_gap(host, NULL);
+                info("%s: SQLite completed with NO ROWs!", REPLICATION_MSG);
+                break;
+            default:
+                error("%s: SQLite returned unexpected error code!", REPLICATION_MSG);
+                break;
+        }
+    }while(rc == SQLITE_ROW);
 
 failed:
     if (unlikely(sqlite3_finalize(res) != SQLITE_OK))
@@ -2235,5 +2237,9 @@ void set_host_gap(RRDHOST *host, sqlite3_stmt *res) {
     host->gaps_timeline->gap_data->t_window.t_start = (time_t) sqlite3_column_int(res, 2);
     host->gaps_timeline->gap_data->t_window.t_first = (time_t) sqlite3_column_int(res, 3); 
     host->gaps_timeline->gap_data->t_window.t_end = (time_t) sqlite3_column_int(res, 4);
-    host->gaps_timeline->gap_data->status = strdupz((char *) sqlite3_column_text(res, 5));
+    host->gaps_timeline->gap_data->status = strdupz((char *) sqlite3_column_text(res, 5));    
+    if (!queue_push(host->gaps_timeline->gaps, (void *)host->gaps_timeline->gap_data)) {
+        error("%s: Cannot insert the loaded GAP in the queue!", REPLICATION_MSG);
+        return;
+    }
 }

--- a/database/sqlite/sqlite_functions.h
+++ b/database/sqlite/sqlite_functions.h
@@ -3,6 +3,7 @@
 #ifndef NETDATA_SQLITE_FUNCTIONS_H
 #define NETDATA_SQLITE_FUNCTIONS_H
 
+#include "libnetdata/libnetdata.h"
 #include "daemon/common.h"
 #include "sqlite3.h"
 

--- a/libnetdata/queue/queue.c
+++ b/libnetdata/queue/queue.c
@@ -18,6 +18,10 @@ int queue_push(queue_t q, void* i)
 	}
 	pthread_mutex_lock(&q->lock);
 	while(q->count == q->max){
+		if(q->blocked == 0){
+			pthread_mutex_unlock(&q->lock);
+			return 0;
+		}
 		pthread_cond_wait(&q->condf, &q->lock);
 	}
 	temp->item = i;
@@ -30,9 +34,10 @@ int queue_push(queue_t q, void* i)
 		q->front = temp;
 	}
 	q->rear = temp;
-    	q->count++; 
-	pthread_cond_signal(&q->conde);
+	q->count++;
+
 	pthread_mutex_unlock(&q->lock);
+	pthread_cond_signal(&q->conde);
 	return 1;
 }
 
@@ -49,6 +54,10 @@ void* queue_pop(queue_t q)
 	pthread_mutex_lock(&q->lock);
 	while(q->count == 0)
 	{
+		if(q->blocked == 0){
+			pthread_mutex_unlock(&q->lock);
+			return temp;
+		}
 		pthread_cond_wait(&q->conde, &q->lock);
 	}
 	
@@ -60,9 +69,10 @@ void* queue_pop(queue_t q)
 		q->rear=NULL;
 	} 
 	q->count--;
-	pthread_cond_signal(&q->condf);
+
 	pthread_mutex_unlock(&q->lock);
-	return temp;						
+	pthread_cond_signal(&q->condf);
+	return temp;
 }
 
 /*
@@ -71,12 +81,13 @@ void* queue_pop(queue_t q)
  * @Return
  *      Returns the queue if it is created successfully, otherwise NULL
  */
-queue_t queue_new(int max){
+queue_t queue_new(int max, int blocked){
 	queue_t q = NULL;
 	q = (queue_t) malloc(sizeof(struct queue_s));	
 	q->front = NULL;			
 	q->rear = NULL;
 	q->max = max;
+	q->blocked = blocked;
 	q->count = 0;
 	q->conde = (pthread_cond_t)PTHREAD_COND_INITIALIZER;
 	q->condf = (pthread_cond_t)PTHREAD_COND_INITIALIZER;

--- a/libnetdata/queue/queue.h
+++ b/libnetdata/queue/queue.h
@@ -22,9 +22,10 @@ struct queue_s{
 	node rear;
 	int max;
 	int count;
+	int blocked;
 };
 
-queue_t queue_new(int size);
+queue_t queue_new(int size, int blocked);
 void queue_free(queue_t q);
 int queue_push(queue_t q, void *data);
 void *queue_pop(queue_t q);				

--- a/streaming/replication.c
+++ b/streaming/replication.c
@@ -528,7 +528,7 @@ void replication_sender_thread_spawn(RRDHOST *host) {
 void send_message(struct replication_state *replication, char* message){
     info("%s: Sending... [%s]", REPLICATION_MSG, message);
     replication_start(replication);
-    buffer_sprintf(replication->build, message);
+    buffer_sprintf(replication->build,"%s", message);
     replication_commit(replication);
     replication_attempt_to_send(replication);
 }
@@ -1402,14 +1402,14 @@ void gaps_init(RRDHOST **a_host)
     }
     RRDHOST *host = *a_host;
     info("%s: LibQueue Initialization", REPLICATION_MSG);
-    host->gaps_timeline->gaps = queue_new(REPLICATION_RX_CMD_Q_MAX_SIZE);
+    host->gaps_timeline->gaps = queue_new(REPLICATION_RX_CMD_Q_MAX_SIZE, false);
     if (!host->gaps_timeline->gaps) {
         error("%s Gaps timeline queue could not be created", REPLICATION_MSG);
         return;
         //Handle this case. Probably shutdown deactivate replication.
     }
     host->gaps_timeline->gap_data = (GAP *)callocz(1, sizeof(GAP));
-    // load from agent metdata
+    // load from agent metadata
     if (!load_gap(host)) {
         infoerr("%s: GAPs struct in SQLITE is either empty or failed", REPLICATION_MSG);
         return;

--- a/streaming/replication.c
+++ b/streaming/replication.c
@@ -1208,6 +1208,21 @@ int load_gap(RRDHOST *host)
         return SQLITE_ERROR;
 
     rc = sql_load_host_gap(host);
+    
+    //Just for test purpose, should be deleted before merging to the master branch 
+    /*
+    for (; ; )
+    {
+        host->gaps_timeline->gap_data = queue_pop(host->gaps_timeline->gaps);
+        if (host->gaps_timeline->gap_data)
+        {
+            print_replication_gap(host->gaps_timeline->gap_data);
+        }else
+        {
+            break;
+        }
+    }
+    */
     if(rc) {
         info("%s: Load GAP from metadata DB in host %s", REPLICATION_MSG, host->hostname);
         print_replication_gap(host->gaps_timeline->gap_data);
@@ -1414,11 +1429,14 @@ void gaps_init(RRDHOST **a_host)
         infoerr("%s: GAPs struct in SQLITE is either empty or failed", REPLICATION_MSG);
         return;
     }
+    //print_replication_gap(host->gaps_timeline->gap_data);
+    /*
     if (!queue_push(host->gaps_timeline->gaps, (void *)host->gaps_timeline->gap_data)) {
         error("%s: Cannot insert the loaded GAP in the queue!", REPLICATION_MSG);
         print_replication_gap(host->gaps_timeline->gap_data);
         return;
     }
+    */
     info("%s: GAPs STRUCT Initialization/Loading", REPLICATION_MSG);
     return;
 }


### PR DESCRIPTION
<!--
Describe the change in summary section, including rationale and design decisions.
Include "Fixes #nnn" if you are fixing an existing issue.

In "Test Plan" provide enough detail on how you plan to test this PR so that a reviewer can validate your tests. If our CI covers sufficient tests, then state which tests cover the change.

If you have more information you want to add, write them in "Additional
Information" section. This is usually used to help others understand your
motivation behind this change. A step-by-step reproduction of the problem is
helpful if there is no related issue.
-->

##### Summary
- integration of the updated libqueue
- pushing gaps from the sqlite to the queue as batch

##### Test Plan
Start the agent 
Check the log file if the queue is loaded with the command: `sudo cat /opt/netdata/var/log/netdata/error.log | grep -A 4  "GAP details are"`
<!---
Provide enough detail so that your reviewer can understand which test-cases you
have covered, and recreate them if necessary. If sufficient tests are covered
by our CI, then state which tests cover the change.
-->

##### Additional Information
