### PR TITLE
[Replication] - Add function which saves all GAPs into the meta-db

### DIFF
--- a/streaming/replication.c
+++ b/streaming/replication.c
@@ -1126,6 +1126,14 @@ int save_gap(GAP *a_gap)
     return rc;
 }
 
+void save_all_gaps(GAPS *gap_timeline){
+    int count = gap_timeline->gaps->count;
+    for(int i = 0; i < count; i++)
+    {
+        save_gap(&gap_timeline->gap_data_table[i]);
+    }
+}
+
 // load gaps from agent metdata db
 int load_gap(RRDHOST *host)
 {

--- a/streaming/replication.h
+++ b/streaming/replication.h
@@ -210,6 +210,7 @@ void replication_collect_past_metric_done(REPLICATION_STATE *rep_state);
 void flush_collected_metric_past_data(RRDDIM_PAST_DATA *dim_past_data, REPLICATION_STATE *rep_state);
 void replication_send_clabels(REPLICATION_STATE *rep_state, RRDSET *st);
 int save_gap(GAP *a_gap);
+void save_all_gaps(GAPS *gap_timeline);
 int remove_gap(GAP *a_gap);
 int remove_all_gaps(void);
 int load_gap(RRDHOST *host);


### PR DESCRIPTION
Add function which saves all GAPs into the meta-db